### PR TITLE
fix: 修改 container.js 的 postsMount 路徑錯誤

### DIFF
--- a/container/src/container.js
+++ b/container/src/container.js
@@ -1,4 +1,4 @@
-import { mount as postsMount } from 'products/ProductsIndex';
+import { mount as postsMount } from 'products/PostsIndex';
 import { mount as cartMount } from 'cart/CartShow';
 
 postsMount(document.querySelector('#my-posts'));


### PR DESCRIPTION
透過 Dev Tool 發現會找不到 `products/ProductsIndex` 的路徑，後來熟讀大大的文章，知道應該要對應至 `posts/webpack.config.js` 的 `exposes` 屬性，再麻煩確認哩。